### PR TITLE
Some rubocop fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'whirly'
-gem 'paint'
 gem 'clipboard'
+gem 'http'
+gem 'paint'
 gem 'rex-text'
 gem 'rspec'
-gem 'http'
 gem 'rubocop'
+gem 'whirly'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/rise
+++ b/bin/rise
@@ -34,7 +34,7 @@ OptionParser.new do |opts|
   end
 end.parse!(ARGV)
 
-if Rise::Util.is_first_run?
+if Rise::Util.first_run?
   Rise::Util.setup
   puts "\nPlease run the `rise` command again to upload your files."
   exit 0

--- a/lib/core/util.rb
+++ b/lib/core/util.rb
@@ -13,11 +13,10 @@ module Rise
   # Utility methods
   #
   module Util
-
     #
     # Checks if rise is being run for the first time
     #
-    def self.is_first_run?
+    def self.first_run?
       !File.directory?(File.join(Dir.home, '.rise'))
     end
 
@@ -25,27 +24,29 @@ module Rise
     # Check for a new version of the gem
     #
     def self.check_for_update!
-      begin
-        output = ''
-        temp = Tempfile.new('rise-updater-output')
-        path = temp.path
-        system("gem outdated > #{path}")
-        output << temp.read
-        if output.include? 'rise-cli'
-          Whirly.start(spinner: 'line', status: Paint['New version available, updating...', 'blue']) do
-            system("gem uninstall rise-cli -v #{Rise::Constants::VERSION} > /dev/null")
-            system("gem install rise-cli > /dev/null")
-            puts Paint["Update complete, just run #{Paint['`rise`', '#3498db']} to deploy"]
-          end
+      output = ''
+      temp = Tempfile.new('rise-updater-output')
+      path = temp.path
+      system("gem outdated > #{path}")
+      output << temp.read
+      if output.include? 'rise-cli'
+        Whirly.start(
+          spinner: 'line',
+          status: Paint['New version available, updating...', 'blue']
+        ) do
+          system("gem uninstall rise-cli -v #{Rise::Constants::VERSION} > /dev/null")
+          system("gem install rise-cli > /dev/null")
+          puts Paint["Update complete, just run #{Paint['`rise`', '#3498db']} to deploy"]
         end
-      rescue Exception => e
-        puts "Unable to check for updates. Error: #{Paint[e.message, 'red']}"
-        exit 1
-      ensure
-        temp.close
-        temp.unlink
       end
+    rescue StandardError => e
+      puts "Unable to check for updates. Error: #{Paint[e.message, 'red']}"
+      exit 1
+    ensure
+      temp.close
+      temp.unlink
     end
+
     #
     # Creates all of the necessary files and login information
     #
@@ -54,23 +55,21 @@ module Rise
       FileUtils.mkdir(RISE_DATA_DIR)
       FileUtils.mkdir(File.join(RISE_DATA_DIR, 'auth'))
 
-      #TODO Reimplement when the backend server actually works
-      # Get the input from the user
-      #print Paint['1. Log in\n2. Sign up\n  > ', :bold]
-      #while (choice = gets.chomp!)
-      #  if choice == '1'
-      #    login
-      #    break
-      #  elsif choice == '2'
-      #    signup
-      #    break
-      #  else
-      #    puts Paint['Please type `1` or `2`', :red]
-      #    next
-      #  end
-      #end
-
+      # TODO: Reimplement when the backend server actually works
+      #  Get the input from the user
+      # print Paint['1. Log in\n2. Sign up\n  > ', :bold]
+      # while (choice = gets.chomp!)
+      #   if choice == '1'
+      #     login
+      #     break
+      #   elsif choice == '2'
+      #     signup
+      #     break
+      #   else
+      #     puts Paint['Please type `1` or `2`', :red]
+      #     next
+      #   end
+      # end
     end
-
   end
 end

--- a/rise-cli.gemspec
+++ b/rise-cli.gemspec
@@ -5,17 +5,16 @@ require 'core'
 Gem::Specification.new do |s|
   s.name        = Rise::Constants::NAME
   s.version     = Rise::Constants::VERSION
-  s.executables = ['rise', 'setup', 'console']
+  s.executables = %w[rise setup console]
   s.date        = Time.now.strftime('%Y-%m-%d')
-  s.summary     = "Simple serverless website deployment"
+  s.summary     = 'Simple serverless website deployment'
   s.authors     = Rise::Constants::AUTHORS
   s.email       = Rise::Constants::EMAIL
   s.files       = `git ls-files`.split($/).reject { |file|
-      file =~ /^server|^spec|^pkg/
-    }
-  s.homepage    =
-    'http://rubygems.org/gems/rise-cli'
-  s.license       = 'MIT'
+    file =~ /^server|^spec|^pkg/
+  }
+  s.homepage    = 'http://rubygems.org/gems/rise-cli'
+  s.license     = 'MIT'
 
   s.add_runtime_dependency 'clipboard'
   s.add_runtime_dependency 'http'


### PR DESCRIPTION
This MR reduces some offenses detected by rubocop. More specifically, I fixed the following problems
```sh
Gemfile:2:1: C: Add an empty line after magic comments.
source 'https://rubygems.org'
^
Gemfile:5:1: C: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem paint should appear before whirly.
gem 'paint'
^^^^^^^^^^^
Gemfile:6:1: C: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem clipboard should appear before paint.
gem 'clipboard'
^^^^^^^^^^^^^^^
Gemfile:8:1: C: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem http should appear before rex-text.
gem 'http'
^^^^^^^^^^
Rakefile:1:9: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
require "bundler/gem_tasks"
        ^^^^^^^^^^^^^^^^^^^
Rakefile:2:9: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
require "rspec/core/rake_task"
        ^^^^^^^^^^^^^^^^^^^^^^
Rakefile:6:6: C: Use the new Ruby 1.9 hash syntax.
task :default => :spec
     ^^^^^^^^^^^
rise-cli.gemspec:8:19: C: Use %w or %W for an array of words.
  s.executables = ['rise', 'setup', 'console']
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rise-cli.gemspec:10:19: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  s.summary     = "Simple serverless website deployment"
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rise-cli.gemspec:15:5: W: } at 15, 4 is not aligned with s.files       = git ls-files.split($/).reject { |file| at 13, 2.
    }
    ^
rise-cli.gemspec:18:12: C: Unnecessary spacing detected.
  s.license       = 'MIT'
           ^^^^^^
rise-cli.gemspec:18:19: C: Operator = should be surrounded by a single space.
  s.license       = 'MIT'
                  ^
lib/core/util.rb:16:1: C: Extra empty line detected at module body beginning.
lib/core/util.rb:20:14: C: Rename is_first_run? to first_run?.
    def self.is_first_run?
             ^^^^^^^^^^^^^
lib/core/util.rb:57:7: C: Missing space after #.
      #TODO Reimplement when the backend server actually works
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/core/util.rb:57:8: C: Annotation keywords like TODO should be all upper case, followed by a colon, and a space, then a note describing the problem.
      #TODO Reimplement when the backend server actually works
       ^^^^^
lib/core/util.rb:59:7: C: Missing space after #.
      #print Paint['1. Log in\n2. Sign up\n  > ', :bold]
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/core/util.rb:60:7: C: Missing space after #.
      #while (choice = gets.chomp!)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/core/util.rb:71:7: C: Missing space after #.
      #end
      ^^^^
lib/core/util.rb:72:1: C: Extra empty line detected at method body end.
lib/core/util.rb:74:1: C: Extra empty line detected at module body end.

```