### PR TITLE
More rubocop fixes

### DIFF
--- a/bin/rise
+++ b/bin/rise
@@ -44,17 +44,16 @@ result_url = ''
 uploader = Rise::Transport::Uploader.new(options[:directory]) unless options[:directory].nil?
 uploader = Rise::Transport::Uploader.new(Dir.pwd) if options[:directory].nil?
 
-
 puts Paint['Thanks for using Rise! Your local source for serverless deployment!', '#95a5a6']
 
 Whirly.start(spinner: 'dots', status: "Uploading files (#{uploader.total_files} total files)") do
   beginning_time = Time.now
-  result_url = uploader.upload!(options[:verbose])  # Do the file upload
+  result_url = uploader.upload!(options[:verbose]) # Do the file upload
 
   Whirly.status = 'Done!\n'
   Clipboard.copy(result_url)
   print Paint["Your url is: #{result_url} (copied to clipboard) ", :bold]
-  puts Paint["[#{((Time.now - beginning_time)).round(2)}s]", "#95a5a6"]
+  puts Paint["[#{((Time.now - beginning_time)).round(2)}s]", '#95a5a6']
 
   puts Paint['Deployment successful!', '#3498db']
 end

--- a/lib/core/transport.rb
+++ b/lib/core/transport.rb
@@ -8,19 +8,18 @@ module Rise
   # Handles all communication with the rise upload server
   #
   module Transport
-
     # Handles uploading files
     class Uploader
-
-      attr_reader :folder_path, :total_files, :include_folder, :uuid, :current_file
+      attr_reader :folder_path, :total_files, :include_folder
+      attr_reader :uuid, :current_file
       attr_accessor :files
 
-      def initialize(folder_path, include_folder=true)
+      def initialize(folder_path, include_folder = true)
         @folder_path    = folder_path
         @files          = Dir.glob("#{File.absolute_path(folder_path)}/**/*")
         @total_files    = @files.length
         @include_folder = include_folder
-        @uuid           = "#{File.basename(File.absolute_path(folder_path))}-#{Rex::Text::rand_text_alphanumeric(8)}"  # Structure: foldername-8RNDLTRS
+        @uuid           = "#{File.basename(File.absolute_path(folder_path))}-#{Rex::Text.rand_text_alphanumeric(8)}" # Structure: foldername-8RNDLTRS
       end
 
       #
@@ -38,18 +37,18 @@ module Rise
         ordered_files = files.sort_by(&:length)
         ordered_files.each do |f|
           isdir = File.directory?(f)
-          final_path = File.absolute_path(f).gsub(File.expand_path(folder_path), '')
+          final_path = File.absolute_path(f).gsub(
+            File.expand_path(folder_path), '')
           uri = URI.parse("#{upload_uri_base}/#{final_path}?dir=#{isdir}")
           begin
-            HTTP.put(uri.to_s, :body => File.read(f))
+            HTTP.put(uri.to_s, body: File.read(f))
           rescue Errno::EISDIR
-            HTTP.put(uri.to_s, :body => '')
+            HTTP.put(uri.to_s, body: '')
             next
           end
         end
-        return access_uri
+        access_uri
       end
-
     end
   end
 end

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'paint'
 gem 'sinatra'
 gem 'sinatra-contrib'
 gem 'thin'
-gem 'paint'

--- a/server/server.rb
+++ b/server/server.rb
@@ -4,13 +4,13 @@ require 'webrick/https'
 require 'openssl'
 
 webrick_options = {
-  :Port             => 443,
-  :DocumentRoot     => "/root/rise-server-public",
-  :SSLEnable        => true,
-  :SSLVerifyClient  => OpenSSL::SSL::VERIFY_NONE,
-  :SSLCertificate   => OpenSSL::X509::Certificate.new(File.read('/etc/letsencrypt/archive/rise.sh/cert1.pem')),
-  :SSLPrivateKey    => OpenSSL::PKey::RSA.new(File.read('/etc/letsencrypt/archive/rise.sh/privkey1.pem')),
-  :SSLCertName      => [[ 'US', WEBrick::Utils::getservername ]]
+  Port:            443,
+  DocumentRoot:    '/root/rise-server-public',
+  SSLEnable:       true,
+  SSLVerifyClient: OpenSSL::SSL::VERIFY_NONE,
+  SSLCertificate:  OpenSSL::X509::Certificate.new(File.read('/etc/letsencrypt/archive/rise.sh/cert1.pem')),
+  SSLPrivateKey:   OpenSSL::PKey::RSA.new(File.read('/etc/letsencrypt/archive/rise.sh/privkey1.pem')),
+  SSLCertName:     [['US', WEBrick::Utils.getservername]]
 }
 
 fork do
@@ -24,7 +24,6 @@ fork do
   get '*' do |path|
     redirect("https://rise.sh#{path}")
   end
-
 end
 
 WEBrick::HTTPServer.new(webrick_options).start


### PR DESCRIPTION
This PR removes 26 rubocop offenses. Now, there are 41 offenses missing. The following offenses were removed:


```sh
lib/core/transport.rb:11:1: C: Extra empty line detected at module body beginning.
lib/core/transport.rb:14:1: C: Extra empty line detected at class body beginning.
lib/core/transport.rb:15:81: C: Line is too long. [83/80]
      attr_reader :folder_path, :total_files, :include_folder, :uuid, :current_file
                                                                                ^^^
lib/core/transport.rb:22:118: C: Unnecessary spacing detected.
        @uuid           = "#{File.basename(File.absolute_path(folder_path))}-#{Rex::Text::rand_text_alphanumeric(8)}"  # Structure: foldername-8RNDLTRS
                                                                                                                     ^
lib/core/transport.rb:22:89: C: Do not use :: for method calls.
        @uuid           = "#{File.basename(File.absolute_path(folder_path))}-#{Rex::Text::rand_text_alphanumeric(8)}"  # Structure: foldername-8RNDLTRS
lib/core/transport.rb:43:32: C: Use the new Ruby 1.9 hash syntax.
            HTTP.put(uri.to_s, :body => File.read(f))
                               ^^^^^^^^
lib/core/transport.rb:45:32: C: Use the new Ruby 1.9 hash syntax.
            HTTP.put(uri.to_s, :body => '')
                               ^^^^^^^^
lib/core/transport.rb:49:9: C: Redundant return detected.
        return access_uri
        ^^^^^^
lib/core/transport.rb:51:1: C: Extra empty line detected at class body end
server/server.rb:7:3: C: Use the new Ruby 1.9 hash syntax.
  :Port             => 443,
  ^^^^^^^^^^^^^^^^^^^^
server/server.rb:8:3: C: Use the new Ruby 1.9 hash syntax.
  :DocumentRoot     => "/root/rise-server-public",
  ^^^^^^^^^^^^^^^^^^^^
server/server.rb:8:24: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  :DocumentRoot     => "/root/rise-server-public",
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
server/server.rb:9:3: C: Use the new Ruby 1.9 hash syntax.
  :SSLEnable        => true,
  ^^^^^^^^^^^^^^^^^^^^
server/server.rb:10:3: C: Use the new Ruby 1.9 hash syntax.
  :SSLVerifyClient  => OpenSSL::SSL::VERIFY_NONE,
  ^^^^^^^^^^^^^^^^^^^^
server/server.rb:11:3: C: Use the new Ruby 1.9 hash syntax.
  :SSLCertificate   => OpenSSL::X509::Certificate.new(File.read('/etc/letsencrypt/archive/rise.sh/cert1.pem')),
  ^^^^^^^^^^^^^^^^^^^^
server/server.rb:12:3: C: Use the new Ruby 1.9 hash syntax.
  :SSLPrivateKey    => OpenSSL::PKey::RSA.new(File.read('/etc/letsencrypt/archive/rise.sh/privkey1.pem')),
  ^^^^^^^^^^^^^^^^^^^^
server/server.rb:13:3: C: Use the new Ruby 1.9 hash syntax.
  :SSLCertName      => [[ 'US', WEBrick::Utils::getservername ]]
  ^^^^^^^^^^^^^^^^^^^^
server/server.rb:13:26: C: Space inside square brackets detected.
  :SSLCertName      => [[ 'US', WEBrick::Utils::getservername ]]
                         ^
server/server.rb:13:47: C: Do not use :: for method calls.
  :SSLCertName      => [[ 'US', WEBrick::Utils::getservername ]]
                                              ^^
server/server.rb:13:62: C: Space inside square brackets detected.
  :SSLCertName      => [[ 'US', WEBrick::Utils::getservername ]]
                                                             ^
server/server.rb:27:1: C: Extra empty line detected at block body end.
        ^^^^^
bin/rise:47:1: C: Extra blank line detected.
bin/rise:52:51: C: Unnecessary spacing detected.
  result_url = uploader.upload!(options[:verbose])  # Do the file upload
                                                  ^
bin/rise:57:62: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  puts Paint["[#{((Time.now - beginning_time)).round(2)}s]", "#95a5a6"]

```